### PR TITLE
更新版本更新脚本为使用awk

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -49,10 +49,19 @@ jobs:
           # 更新 package.json
           npm version $VERSION_NUMBER --no-git-tag-version --prefix GitMentor-Lite
 
-          # 更新 Cargo.toml (使用 cargo-edit 或手动更新)
+          # 更新 Cargo.toml (使用更精确的方法)
           cd GitMentor-Lite/src-tauri
-          # 使用更精确的 sed 命令，只更新 [package] 部分的第一个 version
-          sed -i "0,/^\[package\]/,/^\[/{s/^version = \"[^\"]*\"/version = \"$VERSION_NUMBER\"/}" Cargo.toml
+          # 使用 awk 更安全地更新 [package] 部分的版本
+          awk -v version="$VERSION_NUMBER" '
+          /^\[package\]/ { in_package = 1 }
+          /^\[/ && !/^\[package\]/ { in_package = 0 }
+          in_package && /^version = / && !updated {
+            print "version = \"" version "\""
+            updated = 1
+            next
+          }
+          { print }
+          ' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
 
           # 更新 tauri.conf.json
           cd ../..


### PR DESCRIPTION
修改了版本更新脚本，将sed命令替换为awk以更安全地更新Cargo.toml中的版本号。提高脚本的稳定性和准确性。影响范围限于版本发布流程。
