### PR TITLE
Add manual version input and tag creation options

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,19 @@
-name: 'Release GitMentor'
+name: "Release GitMentor"
 
 on:
   push:
-    tags: ['v*']
+    tags: ["v*"]
   workflow_dispatch:
+    inputs:
+      version:
+        description: "版本号 (例如: v0.1.4, 留空则自动从package.json读取)"
+        required: false
+        type: string
+      create_tag:
+        description: "是否创建新的Git标签"
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -16,18 +26,103 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: 'windows-latest'
-            args: ''
+          - platform: "windows-latest"
+            args: ""
 
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # 获取完整的git历史，用于tag操作
+
+      # 获取版本号 - Author: Evilek, Date: 2025-01-15
+      - name: Get version
+        id: get_version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref_type }}" = "tag" ]; then
+            # 从tag推送获取版本号
+            VERSION="${{ github.ref_name }}"
+            echo "从tag获取版本号: $VERSION"
+          elif [ -n "${{ github.event.inputs.version }}" ]; then
+            # 从手动输入获取版本号
+            VERSION="${{ github.event.inputs.version }}"
+            echo "从输入获取版本号: $VERSION"
+          else
+            # 从package.json自动获取版本号
+            PACKAGE_VERSION=$(node -p "require('./GitMentor-Lite/package.json').version")
+            VERSION="v$PACKAGE_VERSION"
+            echo "从package.json获取版本号: $VERSION"
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "最终版本号: $VERSION"
+
+          # 设置是否需要更新文件的标志
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "need_update=true" >> $GITHUB_OUTPUT
+            echo "需要更新版本文件"
+          else
+            echo "need_update=false" >> $GITHUB_OUTPUT
+            echo "无需更新版本文件"
+          fi
+
+      # 更新版本文件（仅在手动输入版本号时） - Author: Evilek, Date: 2025-01-15
+      - name: Update version files
+        if: steps.get_version.outputs.need_update == 'true'
+        run: |
+          $VERSION = "${{ steps.get_version.outputs.version }}"
+          # 移除v前缀获取纯版本号
+          $CLEAN_VERSION = $VERSION -replace '^v', ''
+          Write-Host "更新版本文件到: $CLEAN_VERSION"
+
+          # 更新package.json
+          $packageJson = Get-Content "GitMentor-Lite/package.json" -Raw | ConvertFrom-Json
+          $packageJson.version = $CLEAN_VERSION
+          $packageJson | ConvertTo-Json -Depth 10 | Set-Content "GitMentor-Lite/package.json"
+          Write-Host "✅ 已更新 package.json"
+
+          # 更新Cargo.toml (使用PowerShell替换第3行)
+          $cargoContent = Get-Content "GitMentor-Lite/src-tauri/Cargo.toml"
+          $cargoContent[2] = "version = `"$CLEAN_VERSION`""
+          $cargoContent | Set-Content "GitMentor-Lite/src-tauri/Cargo.toml"
+          Write-Host "✅ 已更新 Cargo.toml"
+
+          # 更新tauri.conf.json
+          $tauriConfig = Get-Content "GitMentor-Lite/src-tauri/tauri.conf.json" -Raw | ConvertFrom-Json
+          $tauriConfig.version = $CLEAN_VERSION
+          $tauriConfig | ConvertTo-Json -Depth 10 | Set-Content "GitMentor-Lite/src-tauri/tauri.conf.json"
+          Write-Host "✅ 已更新 tauri.conf.json"
+
+          # 提交更改
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add GitMentor-Lite/package.json GitMentor-Lite/src-tauri/Cargo.toml GitMentor-Lite/src-tauri/tauri.conf.json
+          git commit -m "chore: bump version to $VERSION"
+          if ($LASTEXITCODE -eq 0) {
+            git push origin ${{ github.ref_name }}
+            Write-Host "✅ 已提交并推送版本更新"
+          } else {
+            Write-Host "ℹ️ 没有需要提交的更改"
+          }
+        shell: pwsh
+
+      # 创建tag（仅在手动触发且需要时） - Author: Evilek, Date: 2025-01-15
+      - name: Create tag
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.create_tag == 'true'
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          echo "创建tag: $VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
 
       - name: setup node
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: GitMentor-Lite/package-lock.json
 
       - name: install Rust stable
@@ -36,7 +131,7 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          workspaces: './GitMentor-Lite/src-tauri -> target'
+          workspaces: "./GitMentor-Lite/src-tauri -> target"
 
       - name: install frontend dependencies
         working-directory: GitMentor-Lite
@@ -48,21 +143,21 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          projectPath: './GitMentor-Lite'
-          tagName: ${{ github.ref_name }}
-          releaseName: 'GitMentor ${{ github.ref_name }}'
+          projectPath: "./GitMentor-Lite"
+          tagName: ${{ steps.get_version.outputs.version }}
+          releaseName: "GitMentor ${{ steps.get_version.outputs.version }}"
           releaseBody: |
-            ## GitMentor ${{ github.ref_name }}
-            
+            ## GitMentor ${{ steps.get_version.outputs.version }}
+
             ### 🚀 新功能
             - AI 驱动的 Git 提交消息生成
             - 分层提交管理
             - 多语言支持（19种语言）
             - 分支切换和远程同步
-            
+
             ### 📦 下载说明
             - **Windows**: 下载 `.msi` 安装包
-            
+
             ### 🔧 系统要求
             - Windows 10+
             - Git 2.30+


### PR DESCRIPTION
.github/workflows/release.yml: 新增手动输入版本号及创建标签选项，动态更新package.json版本

## 📋 变更描述
简洁明了地描述这个 PR 的变更内容。

## 🔗 相关 Issue
关闭 #(issue 编号)

## 📝 变更类型
请勾选适用的选项：
- [ ] 🐛 Bug 修复 (不破坏现有功能的修复)
- [ ] ✨ 新功能 (不破坏现有功能的新功能)
- [ ] 💥 破坏性变更 (会导致现有功能不工作的修复或功能)
- [ ] 📚 文档更新 (仅文档变更)
- [ ] 🎨 代码风格 (格式化、缺少分号等，不影响代码逻辑)
- [ ] ♻️ 重构 (既不修复 bug 也不添加功能的代码变更)
- [ ] ⚡ 性能优化 (提高性能的代码变更)
- [ ] ✅ 测试 (添加缺失的测试或修正现有测试)
- [ ] 🔧 构建 (影响构建系统或外部依赖的变更)
- [ ] 👷 CI/CD (CI 配置文件和脚本的变更)

## 🧪 测试
描述你如何测试了这些变更：
- [ ] 单元测试通过
- [ ] 集成测试通过
- [ ] 手动测试通过
- [ ] 在以下环境测试：
  - [ ] Windows
  - [ ] macOS  
  - [ ] Linux

## 📸 截图 (如果适用)
如果有 UI 变更，请添加截图。

## ✅ 检查清单
- [ ] 我的代码遵循项目的代码风格指南
- [ ] 我已经对我的代码进行了自我审查
- [ ] 我已经对复杂的代码添加了注释
- [ ] 我已经更新了相关文档
- [ ] 我的变更没有产生新的警告
- [ ] 我已经添加了证明我的修复有效或功能正常的测试
- [ ] 新的和现有的单元测试都通过了
- [ ] 任何依赖的变更都已经合并并发布

## 📝 附加信息
添加任何其他有关此 PR 的上下文信息。
